### PR TITLE
Add automated GitHub release creation on PR merge

### DIFF
--- a/.github/workflows/on-release-merge.yml
+++ b/.github/workflows/on-release-merge.yml
@@ -153,6 +153,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # If this step fails after the release above was created, the source repo won't
+      # have a matching release. See "Failure Recovery" in the header comments for
+      # manual recovery steps using gh api to trigger repository_dispatch.
       - name: Trigger release in source repo
         if: steps.version.outputs.skip != 'true'
         timeout-minutes: 5


### PR DESCRIPTION
## Summary

This workflow automates GitHub release creation when release PRs are merged.

### What it does

When a release PR is merged to `main`:
1. Extracts version from commit message (e.g., "Release v1.4.0 ...")
2. Extracts changelog entries for that version
3. Creates GitHub Release in this repo
4. Triggers release creation in wp-staging-cli source repo via `repository_dispatch`

### Features

- **Approval gate preserved**: No releases until PR is merged
- **Automatic changelog**: Extracts entries from CHANGELOG.md
- **Prerelease support**: Beta/RC versions marked as prerelease
- **Compare links**: Full changelog link comparing versions

### Requirements

- `DEPLOY_TOKEN` secret must have `repo` scope for repository_dispatch access to wp-staging/wp-staging-cli

### Related PR

- wp-staging/wp-staging-cli: feature/automated-release-workflow (adds the receiver workflow)

### Testing

After merging both PRs:
1. Push a test tag (e.g., `v1.4.5-test.1`) to source repo
2. Wait for release PR to be created
3. Merge the PR
4. Verify releases are created in both repos